### PR TITLE
feat: verify url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -845,6 +845,12 @@
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
+    "node_modules/@types/validator": {
+      "version": "13.11.1",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.1.tgz",
+      "integrity": "sha512-d/MUkJYdOeKycmm75Arql4M5+UuXmf4cHdHKsyw1GcvnNgL6s77UkgSgJ8TE/rI5PYsnwYq5jkcWBLuN/MpQ1A==",
+      "dev": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.2.1.tgz",
@@ -2467,6 +2473,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vite": {
       "version": "4.4.7",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.7.tgz",
@@ -2586,9 +2600,11 @@
       "name": "@dcl/single-sign-on-client",
       "version": "0.0.1",
       "dependencies": {
-        "@dcl/crypto": "^3.4.3"
+        "@dcl/crypto": "^3.4.3",
+        "validator": "^13.11.0"
       },
       "devDependencies": {
+        "@types/validator": "^13.11.1",
         "typescript": "^5.0.2"
       }
     }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -10,9 +10,11 @@
     "build": "rm -rf dist && tsc"
   },
   "devDependencies": {
+    "@types/validator": "^13.11.1",
     "typescript": "^5.0.2"
   },
   "dependencies": {
-    "@dcl/crypto": "^3.4.3"
+    "@dcl/crypto": "^3.4.3",
+    "validator": "^13.11.0"
   }
 }

--- a/packages/lib/src/SingleSignOn.shared.ts
+++ b/packages/lib/src/SingleSignOn.shared.ts
@@ -1,4 +1,4 @@
-import { AuthIdentity } from "@dcl/crypto";
+import type { AuthIdentity } from "@dcl/crypto";
 
 // The possible typo of interactions with the iframe.
 export enum Action {

--- a/packages/lib/src/SingleSignOn.ts
+++ b/packages/lib/src/SingleSignOn.ts
@@ -1,4 +1,5 @@
-import { AuthIdentity } from "@dcl/crypto";
+import type { AuthIdentity } from "@dcl/crypto";
+import isURL, { IsURLOptions } from "validator/lib/isURL";
 import {
   Action,
   ClientMessage,
@@ -29,8 +30,17 @@ let _counter = 0;
 // Being an empty string or not indicates if the iframe has been initialized with the `init` function.
 let _src = "";
 
+const defaultOptions: IsURLOptions = {
+  protocols: ["https"],
+  require_protocol: true,
+}
+
 // Initializes the client by appending the SSO iframe to the document.
-export function init(src: string) {
+export function init(src: string, options: IsURLOptions = {}) {
+  if (!isURL(src, { ...defaultOptions, ...options })) {
+    throw new Error(`Invalid url: ${src}`);
+  }
+
   if (_src) {
     throw new Error("Already initialized");
   }


### PR DESCRIPTION
This PR ensures the `init` function can only be called using a valid URL, by default, the URL should be `https` but that restriction can be optionally disabled by using an extra parameter