### PR TITLE
docs: deprecate in favor of the core-libs monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Single Sign On Client
 
+> [!WARNING]
+> **This repository is deprecated.** `@dcl/single-sign-on-client` has moved to the [`decentraland/core-libs`](https://github.com/decentraland/core-libs) monorepo and is now developed and published from [`libs/single-sign-on-client`](https://github.com/decentraland/core-libs/tree/main/libs/single-sign-on-client).
+>
+> Please open issues and pull requests against [`decentraland/core-libs`](https://github.com/decentraland/core-libs). This repository will stop receiving updates.
+
 Repo containing the @dcl/single-sign-on-client library code as well as a demo.
 
 The README for the library can be found [here](https://github.com/decentraland/single-sign-on-client/blob/main/packages/lib/README.md).

--- a/packages/lib/README.md
+++ b/packages/lib/README.md
@@ -1,5 +1,10 @@
 # Single Sign On Client
 
+> [!WARNING]
+> **This repository is deprecated.** `@dcl/single-sign-on-client` has moved to the [`decentraland/core-libs`](https://github.com/decentraland/core-libs) monorepo and is now developed and published from [`libs/single-sign-on-client`](https://github.com/decentraland/core-libs/tree/main/libs/single-sign-on-client).
+>
+> Please open issues and pull requests against [`decentraland/core-libs`](https://github.com/decentraland/core-libs). This repository will stop receiving updates.
+
 Code that abstracts interaction with the single sign on iframe.
 
 https://github.com/decentraland/single-sign-on <- Single Sign On webapp repo.


### PR DESCRIPTION
## Summary
Adds a deprecation notice to the root and library READMEs. `@dcl/single-sign-on-client` has moved to the [`decentraland/core-libs`](https://github.com/decentraland/core-libs) monorepo and is now developed and published from [`libs/single-sign-on-client`](https://github.com/decentraland/core-libs/tree/main/libs/single-sign-on-client).

## Why
This package is being consolidated into `core-libs` alongside the other shared Decentraland libraries. New issues and pull requests should be filed there; this repository will stop receiving updates.

## What changed
- `README.md` and `packages/lib/README.md` (the npm-published README) each get a `> [!WARNING]` deprecation callout pointing to the new home, matching the style used by other migrated repos (e.g. [`urn-resolver`](https://github.com/decentraland/urn-resolver)).

## Related
- Companion PR adding the library to the monorepo: decentraland/core-libs#28